### PR TITLE
fix(parser): resolve early return preventing parameter binding

### DIFF
--- a/src/modules/QueryParser.js
+++ b/src/modules/QueryParser.js
@@ -28,30 +28,42 @@ class QueryParser {
             switch (cmd) {
                 case 'LAHAN':
                 case 'CREATE':
-                    if (tokens[1] && tokens[1].toUpperCase() === 'INDEX') return this.parseCreateIndex(tokens);
-                    return this.parseCreate(tokens);
+                    if (tokens[1] && tokens[1].toUpperCase() === 'INDEX') {
+                        command = this.parseCreateIndex(tokens);
+                    } else {
+                        command = this.parseCreate(tokens);
+                    }
+                    break;
                 case 'LIHAT':
                 case 'SHOW':
-                    return this.parseShow(tokens);
+                    command = this.parseShow(tokens);
+                    break;
                 case 'TANAM':
                 case 'INSERT':
-                    return this.parseInsert(tokens);
+                    command = this.parseInsert(tokens);
+                    break;
                 case 'PANEN':
                 case 'SELECT':
-                    return this.parseSelect(tokens);
+                    command = this.parseSelect(tokens);
+                    break;
                 case 'GUSUR':
                 case 'DELETE':
-                    return this.parseDelete(tokens);
+                    command = this.parseDelete(tokens);
+                    break;
                 case 'PUPUK':
                 case 'UPDATE':
-                    return this.parseUpdate(tokens);
+                    command = this.parseUpdate(tokens);
+                    break;
                 case 'BAKAR':
                 case 'DROP':
-                    return this.parseDrop(tokens);
+                    command = this.parseDrop(tokens);
+                    break;
                 case 'INDEKS':
-                    return this.parseCreateIndex(tokens);
+                    command = this.parseCreateIndex(tokens);
+                    break;
                 case 'HITUNG':
-                    return this.parseAggregate(tokens);
+                    command = this.parseAggregate(tokens);
+                    break;
                 default:
                     throw new Error(`Perintah tidak dikenal: ${cmd}`);
             }


### PR DESCRIPTION
Previously, the `parse` method inside src/modules/QueryParser.js returned the command object immediately within the switch-case block.

This caused the code execution to exit before reaching `_bindParameters(command, params)`, rendering the parameter binding logic (handling @placeholders) unreachable.

This commit changes the flow to assign the result to a `command` variable and uses `break`, ensuring the parameter binding logic at the end of the function is executed.